### PR TITLE
fill scan info should behave like fill dataset metadata

### DIFF
--- a/ontologies/parse.py
+++ b/ontologies/parse.py
@@ -128,7 +128,7 @@ def generate_docs():
 
     table = [
         {
-            "Name": f'<a href="{technique.iri}">{technique.names[0]}</a>',  # noqa W604
+            "Name": f'<a href="{technique.iri}">{technique.primary_name}</a>',  # noqa W604
             "Alternative names": ", ".join(technique.names[1:]),
             "Description": technique.description,
         }

--- a/src/esrf_ontologies/technique/types.py
+++ b/src/esrf_ontologies/technique/types.py
@@ -59,14 +59,8 @@ class TechniqueMetadata:
         }
 
     def _fill_nxnote(self, nxnote: MutableMapping) -> None:
-        try:
-            names = nxnote["names"]
-        except KeyError:
-            names = list()
-        try:
-            iris = nxnote["iris"]
-        except KeyError:
-            iris = list()
+        names = nxnote.get("names", [])
+        iris = nxnote.get("iris", [])
         techniques = dict(zip(iris, names))
         for technique in self.techniques:
             techniques[technique.iri] = technique.names[0]

--- a/src/esrf_ontologies/technique/types.py
+++ b/src/esrf_ontologies/technique/types.py
@@ -39,7 +39,10 @@ class TechniqueMetadata:
         scan_meta_categories = scan_info.setdefault("scan_meta_categories", list())
         if "techniques" not in scan_meta_categories:
             scan_meta_categories.append("techniques")
-        scan_info["techniques"] = self._get_nxnote()
+        nxnote = scan_info.get("techniques")
+        if nxnote is None:
+            nxnote = scan_info["techniques"] = dict()
+        self._fill_nxnote(nxnote)
 
     def _get_nxnote(self) -> Dict[str, Union[List[str], str]]:
         names = list()
@@ -54,6 +57,27 @@ class TechniqueMetadata:
             "names": names,
             "iris": iris,
         }
+
+    def _fill_nxnote(self, nxnote: MutableMapping) -> None:
+        try:
+            names = nxnote["names"]
+        except KeyError:
+            names = list()
+        try:
+            iris = nxnote["iris"]
+        except KeyError:
+            iris = list()
+        techniques = dict(zip(iris, names))
+        for technique in self.techniques:
+            techniques[technique.iri] = technique.names[0]
+        iris, names = zip(*sorted(techniques.items(), key=lambda tpl: tpl[1]))
+        nxnote.update(
+            {
+                "@NX_class": "NXnote",
+                "names": list(names),
+                "iris": list(iris),
+            }
+        )
 
     def fill_dataset_metadata(self, dataset: MutableMapping) -> None:
         if not self.techniques:

--- a/src/esrf_ontologies/technique/types.py
+++ b/src/esrf_ontologies/technique/types.py
@@ -13,6 +13,10 @@ class Technique:
     names: Tuple[str]  # Human readable name (first is the perferred one)
     description: str  # Human readable description
 
+    @property
+    def primary_name(self) -> str:
+        return self.names[0]
+
 
 @dataclasses.dataclass
 class TechniqueMetadata:
@@ -48,9 +52,9 @@ class TechniqueMetadata:
         names = list()
         iris = list()
         for technique in sorted(
-            self.techniques, key=lambda technique: technique.names[0]
+            self.techniques, key=lambda technique: technique.primary_name
         ):
-            names.append(technique.names[0])
+            names.append(technique.primary_name)
             iris.append(technique.iri)
         return {
             "@NX_class": "NXnote",
@@ -63,7 +67,7 @@ class TechniqueMetadata:
         iris = nxnote.get("iris", [])
         techniques = dict(zip(iris, names))
         for technique in self.techniques:
-            techniques[technique.iri] = technique.names[0]
+            techniques[technique.iri] = technique.primary_name
         iris, names = zip(*sorted(techniques.items(), key=lambda tpl: tpl[1]))
         nxnote.update(
             {
@@ -88,7 +92,7 @@ class TechniqueMetadata:
             pids = list()
         techniques = dict(zip(pids, definitions))
         for technique in self.techniques:
-            techniques[technique.iri] = technique.names[0]
+            techniques[technique.iri] = technique.primary_name
         for key, value in self._get_icat_metadata(techniques).items():
             try:
                 dataset[key] = value
@@ -104,7 +108,7 @@ class TechniqueMetadata:
         if not self.techniques:
             return dict()
         techniques = {
-            technique.iri: technique.names[0] for technique in self.techniques
+            technique.iri: technique.primary_name for technique in self.techniques
         }
         return self._get_icat_metadata(techniques)
 

--- a/src/esrf_ontologies/tests/test_single_technique_metadata.py
+++ b/src/esrf_ontologies/tests/test_single_technique_metadata.py
@@ -61,8 +61,11 @@ def test_fill_scan_info():
         "scan_meta_categories": ["techniques", "technique"],
         "techniques": {
             "@NX_class": "NXnote",
-            "names": ["XAS"],
-            "iris": ["http://purl.org/pan-science/ESRFET#XAS"],
+            "names": ["XAS", "XRF"],
+            "iris": [
+                "http://purl.org/pan-science/ESRFET#XAS",
+                "http://purl.org/pan-science/ESRFET#XRF",
+            ],
         },
     }
     info = {


### PR DESCRIPTION
When preparing the BCU meeting I had this table for the API of the metadata generator object

Method | Result | Comments
-- | -- | --
get_dataset_metadata() -> dict | {&apos;definition&apos;: &apos;XRD XRF&apos;,&apos;technique_pid&apos;: &apos;http://purl.org/pan-science/ESRFET#XRD &apos;                 &apos;http://purl.org/pan-science/ESRFET#XRF&apos;} | ICAT metadata keys.
fill_dataset_metadata(dataset: dict) -> None | {&apos;definition&apos;: &apos;XRD XRF&apos;,&apos;technique_pid&apos;: &apos;http://purl.org/pan-science/ESRFET#XRD &apos;                 &apos;http://purl.org/pan-science/ESRFET#XRF&apos;} | ICAT metadata keys. Appends to existing techniques.
get_scan_metadata() -> dict | {&apos;@NX_class&apos;: &apos;NXnote&apos;,&apos;iris&apos;: [&apos;http://purl.org/pan-science/ESRFET#XRD&apos;,         &apos;http://purl.org/pan-science/ESRFET#XRF&apos;],&apos;names&apos;: [&apos;XRD&apos;, &apos;XRF&apos;]} | Raw HDF5/Nexus group content.
get_scan_info()-> dict | {&apos;scan_meta_categories&apos;: [&apos;techniques&apos;],&apos;techniques&apos;: {&apos;@NX_class&apos;: &apos;NXnote&apos;,               &apos;iris&apos;: [&apos;http://purl.org/pan-science/ESRFET#XRD&apos;,                        &apos;http://purl.org/pan-science/ESRFET#XRF&apos;],               &apos;names&apos;: [&apos;XRD&apos;, &apos;XRF&apos;]}} | HDF5/Nexus group content for blisswriter.
fill_scan_info(scan_info: dict) -> None | {&apos;scan_meta_categories&apos;: [&apos;techniques&apos;],&apos;techniques&apos;: {&apos;@NX_class&apos;: &apos;NXnote&apos;,               &apos;iris&apos;: [&apos;http://purl.org/pan-science/ESRFET#XRD&apos;,                        &apos;http://purl.org/pan-science/ESRFET#XRF&apos;],               &apos;names&apos;: [&apos;XRD&apos;, &apos;XRF&apos;]}} | HDF5/Nexus group content for blisswriter. Replaces existing techniques but appends to the categories.

But I think the last one is confusion. This MR makes `fill_scan_info` behave like `fill_dataset_metadata`.