### PR TITLE
Resolve contrast in dark theme for striped tables

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -14,3 +14,7 @@
     padding: 8px 12px;
     border: 1px solid #ddd;
 }
+
+html[data-theme="dark"] table.table-striped tbody tr:nth-child(odd) td {
+    color: #ddd  !important;
+}


### PR DESCRIPTION
https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/light-dark.html

![ontologies](https://github.com/user-attachments/assets/c707556a-ca36-47a2-a266-e2feb1bdbde7)
