### PR TITLE
59 add giwaxs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,13 @@ jobs:
       - name: Check transpilation did not modify the python project
         run: |
           git diff --exit-code
+
+      - name: Check ontology capitalization (X-ray vs X-Ray)
+        run: |
+          FILES="./ontologies/esrfet/ESRFET.owl ./ontologies/esrffair/ESRFFAIR.owl"
+          if grep -nR "X-Ray" $FILES; then
+            echo "❌ Found incorrect capitalization 'X-Ray'. Please use 'X-ray'."
+            exit 1
+          else
+            echo "✅ No incorrect capitalization found."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Check ontology capitalization (X-ray vs X-Ray)
         run: |
           FILES="./ontologies/esrfet/ESRFET.owl ./ontologies/esrffair/ESRFFAIR.owl"
-          if grep -nR "X-Ray" $FILES; then
+          if grep -nRE "(X-Ray|x-ray)" $FILES | grep -vE 'IRI="#|<IRI>#'; then
             echo "❌ Found incorrect capitalization 'X-Ray'. Please use 'X-ray'."
             exit 1
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FF-EXAFS: add semantic meaning
 - TR-MX: new technique
 - TR-SSX: new technique
+- GIWAXS: new technique
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FF-EXAFS: add semantic meaning
 - TR-MX: new technique
 - TR-SSX: new technique
-- GIWAXS: new technique
+- GIWAXS: new technique with semantic meaning
+- GIXRD: add semantic meaning
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GIWAXS: new technique with semantic meaning
 - GIXRD: add semantic meaning
 
+### Changes
+
+- Use “X-ray”, with a lowercase r.
+
 ## [1.0.0]
 
 ### Added

--- a/doc/_ext/techniques.json
+++ b/doc/_ext/techniques.json
@@ -142,12 +142,17 @@
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#GISAXS\">GISAXS</a>",
     "Alternative names": "Grazing Incidence Small Angle X-ray Scattering",
-    "Description": "Grazing Incidence Small Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about surface and thin film morphology, including size, shape, and arrangement of nanostructures."
+    "Description": "Grazing-Incidence Small-Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about thin film and surface morphology, including size, shape, and arrangement of nanostructures."
+  },
+  {
+    "Name": "<a href=\"http://purl.org/pan-science/ESRFET#GIWAXS\">GIWAXS</a>",
+    "Alternative names": "Grazing Incidence Wide Angle X-ray Scattering",
+    "Description": "Grazing-Incidence Wide-Angle X-ray Scattering (GIWAXS) measures scattered X-rays at wide angles under shallow incidence, providing information on molecular packing, crystalline order, and orientation in thin films and surfaces."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#GIXRD\">GIXRD</a>",
     "Alternative names": "Grazing Incidence X-Ray Diffraction",
-    "Description": "Grazing Incidence X-Ray Diffraction (GIXRD) measures diffraction from a sample surface using X-rays at very shallow incident angles, providing structural information about thin films, surfaces, and near-surface regions."
+    "Description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#HAXPES\">HAXPES</a>",

--- a/doc/_ext/techniques.json
+++ b/doc/_ext/techniques.json
@@ -152,7 +152,7 @@
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#GIXRD\">GIXRD</a>",
     "Alternative names": "Grazing Incidence X-Ray Diffraction",
-    "Description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
+    "Description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#HAXPES\">HAXPES</a>",

--- a/doc/_ext/techniques.json
+++ b/doc/_ext/techniques.json
@@ -1,7 +1,7 @@
 [
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#3DXRD\">3DXRD</a>",
-    "Alternative names": "3D X-Ray Diffraction",
+    "Alternative names": "3D X-ray Diffraction",
     "Description": "3DXRD is a far field diffraction technique capable of reconstructing polycrystalline materials from the individual diffraction spots recorded in the diffraction pattern given that the crystallographic parameters of the material are known. The success of the technique is based on the ability of the individual diffraction spots to be separated. This means there is a trade off between the number of grains and the degree of strain that is measurable."
   },
   {
@@ -21,7 +21,7 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#CDI\">CDI</a>",
-    "Alternative names": "Coherent Diffraction Imaging, CXD, CXDI, Coherent X-Ray Diffraction, Coherent X-ray Diffraction Imaging",
+    "Alternative names": "Coherent Diffraction Imaging, CXD, CXDI, Coherent X-ray Diffraction, Coherent X-ray Diffraction Imaging",
     "Description": "Coherent Diffraction Imaging (CDI) measures the far-field diffraction pattern from a sample illuminated with a coherent X-ray beam. The image of the sample is reconstructed computationally from the diffraction data using phase retrieval algorithms, yielding high-resolution, lensless imaging of the electron density or scattering potential."
   },
   {
@@ -151,7 +151,7 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#GIXRD\">GIXRD</a>",
-    "Alternative names": "Grazing Incidence X-Ray Diffraction",
+    "Alternative names": "Grazing Incidence X-ray Diffraction",
     "Description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
   {
@@ -386,8 +386,8 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#TR-XRD\">TR-XRD</a>",
-    "Alternative names": "Time Resolved X-Ray Diffraction",
-    "Description": "Time-Resolved X-Ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials."
+    "Alternative names": "Time Resolved X-ray Diffraction",
+    "Description": "Time-Resolved X-ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#TR‑SSX\">TR‑SSX</a>",
@@ -401,8 +401,8 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#USA-XPCS\">USA-XPCS</a>",
-    "Alternative names": "Ultra-Small Angle X-Ray Photon Correlation Spectroscopy",
-    "Description": "Ultra-Small Angle X-Ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials."
+    "Alternative names": "Ultra-Small Angle X-ray Photon Correlation Spectroscopy",
+    "Description": "Ultra-Small Angle X-ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#USAXS\">USAXS</a>",
@@ -451,8 +451,8 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XDS\">XDS</a>",
-    "Alternative names": "X-Ray Diffuse Scattering",
-    "Description": "X-Ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials."
+    "Alternative names": "X-ray Diffuse Scattering",
+    "Description": "X-ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XEOL\">XEOL</a>",
@@ -481,7 +481,7 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XLD\">XLD</a>",
-    "Alternative names": "X-Ray Linear Dichroism",
+    "Alternative names": "X-ray Linear Dichroism",
     "Description": "X-ray Linear Dichroism (XLD) measures the difference in X-ray absorption for linearly polarized light oriented along different crystallographic axes, providing information on electronic anisotropy and orbital ordering."
   },
   {
@@ -516,8 +516,8 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XPCS\">XPCS</a>",
-    "Alternative names": "X-Ray Photon Correlation Spectroscopy",
-    "Description": "X-Ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes."
+    "Alternative names": "X-ray Photon Correlation Spectroscopy",
+    "Description": "X-ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XPCT\">XPCT</a>",
@@ -536,8 +536,8 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XRCT\">XRCT</a>",
-    "Alternative names": "X-Ray Computed Tomography",
-    "Description": "X-Ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample."
+    "Alternative names": "X-ray Computed Tomography",
+    "Description": "X-ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample."
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XRD\">XRD</a>",
@@ -566,7 +566,7 @@
   },
   {
     "Name": "<a href=\"http://purl.org/pan-science/ESRFET#XRT\">XRT</a>",
-    "Alternative names": "X-Ray Topography, X-Ray Diffraction Topography, XDT",
-    "Description": "X-Ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure."
+    "Alternative names": "X-ray Topography, X-ray Diffraction Topography, XDT",
+    "Description": "X-ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure."
   }
 ]

--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -99,6 +99,9 @@
         <Class IRI="#GISAXS"/>
     </Declaration>
     <Declaration>
+        <Class IRI="#GIWAXS"/>
+    </Declaration>
+    <Declaration>
         <Class IRI="#GIXRD"/>
     </Declaration>
     <Declaration>
@@ -1935,6 +1938,10 @@
         <Class IRI="#experimental_technique"/>
     </SubClassOf>
     <SubClassOf>
+        <Class IRI="#GIWAXS"/>
+        <Class IRI="#experimental_technique"/>
+    </SubClassOf>
+    <SubClassOf>
         <Class IRI="#GIXRD"/>
         <Class IRI="#experimental_technique"/>
     </SubClassOf>
@@ -2978,7 +2985,7 @@
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#GISAXS</IRI>
-        <Literal>Grazing Incidence Small Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about surface and thin film morphology, including size, shape, and arrangement of nanostructures.</Literal>
+        <Literal>Grazing-Incidence Small-Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about thin film and surface morphology, including size, shape, and arrangement of nanostructures.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -2992,8 +2999,23 @@
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#GIWAXS</IRI>
+        <Literal>Grazing-Incidence Wide-Angle X-ray Scattering (GIWAXS) measures scattered X-rays at wide angles under shallow incidence, providing information on molecular packing, crystalline order, and orientation in thin films and surfaces.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#GIWAXS</IRI>
+        <Literal>GIWAXS</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
+        <IRI>#GIWAXS</IRI>
+        <Literal>Grazing Incidence Wide Angle X-ray Scattering</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#GIXRD</IRI>
-        <Literal>Grazing Incidence X-Ray Diffraction (GIXRD) measures diffraction from a sample surface using X-rays at very shallow incident angles, providing structural information about thin films, surfaces, and near-surface regions.</Literal>
+        <Literal>Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>

--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -2662,7 +2662,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#altLabel"/>
         <IRI>#CDI</IRI>
-        <Literal>Coherent X-Ray Diffraction</Literal>
+        <Literal>Coherent X-ray Diffraction</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#altLabel"/>
@@ -3057,7 +3057,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#GIXRD</IRI>
-        <Literal>Grazing Incidence X-Ray Diffraction</Literal>
+        <Literal>Grazing Incidence X-ray Diffraction</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -3850,7 +3850,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#TR-XRD</IRI>
-        <Literal>Time-Resolved X-Ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials.</Literal>
+        <Literal>Time-Resolved X-ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -3860,7 +3860,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#TR-XRD</IRI>
-        <Literal>Time Resolved X-Ray Diffraction</Literal>
+        <Literal>Time Resolved X-ray Diffraction</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -3880,7 +3880,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#USA-XPCS</IRI>
-        <Literal>Ultra-Small Angle X-Ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials.</Literal>
+        <Literal>Ultra-Small Angle X-ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -3890,7 +3890,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#USA-XPCS</IRI>
-        <Literal>Ultra-Small Angle X-Ray Photon Correlation Spectroscopy</Literal>
+        <Literal>Ultra-Small Angle X-ray Photon Correlation Spectroscopy</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4030,7 +4030,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#XDS</IRI>
-        <Literal>X-Ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials.</Literal>
+        <Literal>X-ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -4040,7 +4040,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#XDS</IRI>
-        <Literal>X-Ray Diffuse Scattering</Literal>
+        <Literal>X-ray Diffuse Scattering</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4130,7 +4130,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#XLD</IRI>
-        <Literal>X-Ray Linear Dichroism</Literal>
+        <Literal>X-ray Linear Dichroism</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4235,7 +4235,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#XPCS</IRI>
-        <Literal>X-Ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes.</Literal>
+        <Literal>X-ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -4245,7 +4245,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#XPCS</IRI>
-        <Literal>X-Ray Photon Correlation Spectroscopy</Literal>
+        <Literal>X-ray Photon Correlation Spectroscopy</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4295,7 +4295,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#XRCT</IRI>
-        <Literal>X-Ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample.</Literal>
+        <Literal>X-ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -4305,7 +4305,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#XRCT</IRI>
-        <Literal>X-Ray Computed Tomography</Literal>
+        <Literal>X-ray Computed Tomography</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4395,7 +4395,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#XRT</IRI>
-        <Literal>X-Ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure.</Literal>
+        <Literal>X-ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
@@ -4405,7 +4405,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#altLabel"/>
         <IRI>#XRT</IRI>
-        <Literal>X-Ray Diffraction Topography</Literal>
+        <Literal>X-ray Diffraction Topography</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#altLabel"/>
@@ -4415,7 +4415,7 @@ The second definition is chosen for this technique.</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#XRT</IRI>
-        <Literal>X-Ray Topography</Literal>
+        <Literal>X-ray Topography</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
@@ -4829,7 +4829,7 @@ Ultra Large structural features: large aggregates, clusters, and larger pores</L
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://www.w3.org/2004/02/skos/core#prefLabel"/>
         <IRI>#3DXRD</IRI>
-        <Literal>3D X-Ray Diffraction</Literal>
+        <Literal>3D X-ray Diffraction</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -3047,7 +3047,7 @@
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>#GIXRD</IRI>
-        <Literal>Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain.</Literal>
+        <Literal>Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>

--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -4670,7 +4670,7 @@ Large structural features: supramolecular structures, particle sizes, and shapes
 
                 Another way of looking at it:
                 diffraction (cascade of events being detected) requires &apos;any of&apos; single crystal, powder, fiber
-                x-ray powder diffraction (technique) requires &apos;exactly&apos; powder</Literal>
+                X-ray powder diffraction (technique) requires &apos;exactly&apos; powder</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -1104,6 +1104,46 @@
         </ObjectIntersectionOf>
     </EquivalentClasses>
     <EquivalentClasses>
+        <Class IRI="#GIWAXS"/>
+        <ObjectIntersectionOf>
+            <Class IRI="#experimental_technique"/>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#measures_interaction_result_property"/>
+                <Class IRI="#small_length_scales"/>
+            </ObjectSomeValuesFrom>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#measures_result_of_interaction"/>
+                <Class IRI="#diffraction_of_elastic_scattering"/>
+            </ObjectSomeValuesFrom>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#requires_sample_input"/>
+                <Class IRI="#x-ray"/>
+            </ObjectSomeValuesFrom>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#requires_sample_input_property"/>
+                <Class IRI="#sample_incident_angle_smaller_than_critical_angle"/>
+            </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+    </EquivalentClasses>
+    <EquivalentClasses>
+        <Class IRI="#GIXRD"/>
+        <ObjectIntersectionOf>
+            <Class IRI="#experimental_technique"/>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#measures_result_of_interaction"/>
+                <Class IRI="#diffraction_of_elastic_scattering"/>
+            </ObjectSomeValuesFrom>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#requires_sample_input"/>
+                <Class IRI="#x-ray"/>
+            </ObjectSomeValuesFrom>
+            <ObjectSomeValuesFrom>
+                <ObjectProperty IRI="#requires_sample_input_property"/>
+                <Class IRI="#sample_incident_angle_smaller_than_critical_angle"/>
+            </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+    </EquivalentClasses>
+    <EquivalentClasses>
         <Class IRI="#HERFD-XAS"/>
         <ObjectIntersectionOf>
             <Class IRI="#experimental_technique"/>
@@ -1935,14 +1975,6 @@
     </SubClassOf>
     <SubClassOf>
         <Class IRI="#EM"/>
-        <Class IRI="#experimental_technique"/>
-    </SubClassOf>
-    <SubClassOf>
-        <Class IRI="#GIWAXS"/>
-        <Class IRI="#experimental_technique"/>
-    </SubClassOf>
-    <SubClassOf>
-        <Class IRI="#GIXRD"/>
         <Class IRI="#experimental_technique"/>
     </SubClassOf>
     <SubClassOf>

--- a/src/esrf_ontologies/db/ESRFET.json
+++ b/src/esrf_ontologies/db/ESRFET.json
@@ -249,7 +249,7 @@
       "GIXRD",
       "Grazing Incidence X-Ray Diffraction"
     ],
-    "description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
+    "description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#HAXPES",

--- a/src/esrf_ontologies/db/ESRFET.json
+++ b/src/esrf_ontologies/db/ESRFET.json
@@ -3,7 +3,7 @@
     "iri": "http://purl.org/pan-science/ESRFET#3DXRD",
     "names": [
       "3DXRD",
-      "3D X-Ray Diffraction"
+      "3D X-ray Diffraction"
     ],
     "description": "3DXRD is a far field diffraction technique capable of reconstructing polycrystalline materials from the individual diffraction spots recorded in the diffraction pattern given that the crystallographic parameters of the material are known. The success of the technique is based on the ability of the individual diffraction spots to be separated. This means there is a trade off between the number of grains and the degree of strain that is measurable."
   },
@@ -37,7 +37,7 @@
       "Coherent Diffraction Imaging",
       "CXD",
       "CXDI",
-      "Coherent X-Ray Diffraction",
+      "Coherent X-ray Diffraction",
       "Coherent X-ray Diffraction Imaging"
     ],
     "description": "Coherent Diffraction Imaging (CDI) measures the far-field diffraction pattern from a sample illuminated with a coherent X-ray beam. The image of the sample is reconstructed computationally from the diffraction data using phase retrieval algorithms, yielding high-resolution, lensless imaging of the electron density or scattering potential."
@@ -247,7 +247,7 @@
     "iri": "http://purl.org/pan-science/ESRFET#GIXRD",
     "names": [
       "GIXRD",
-      "Grazing Incidence X-Ray Diffraction"
+      "Grazing Incidence X-ray Diffraction"
     ],
     "description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
@@ -640,9 +640,9 @@
     "iri": "http://purl.org/pan-science/ESRFET#TR-XRD",
     "names": [
       "TR-XRD",
-      "Time Resolved X-Ray Diffraction"
+      "Time Resolved X-ray Diffraction"
     ],
-    "description": "Time-Resolved X-Ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials."
+    "description": "Time-Resolved X-ray Diffraction (TR-XRD) measures changes in X-ray diffraction patterns as a function of time to study dynamic processes such as phase transitions, chemical reactions, and structural changes in materials."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#TR\u2011SSX",
@@ -664,9 +664,9 @@
     "iri": "http://purl.org/pan-science/ESRFET#USA-XPCS",
     "names": [
       "USA-XPCS",
-      "Ultra-Small Angle X-Ray Photon Correlation Spectroscopy"
+      "Ultra-Small Angle X-ray Photon Correlation Spectroscopy"
     ],
-    "description": "Ultra-Small Angle X-Ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials."
+    "description": "Ultra-Small Angle X-ray Photon Correlation Spectroscopy (USA-XPCS) measures time-dependent fluctuations of coherent X-ray scattering at ultra-small angles to probe slow dynamics and structural rearrangements on large length scales in complex materials."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#USAXS",
@@ -744,9 +744,9 @@
     "iri": "http://purl.org/pan-science/ESRFET#XDS",
     "names": [
       "XDS",
-      "X-Ray Diffuse Scattering"
+      "X-ray Diffuse Scattering"
     ],
-    "description": "X-Ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials."
+    "description": "X-ray Diffuse Scattering (XDS) measures scattered X-rays away from Bragg peaks to probe local disorder, defects, thermal vibrations, and nanoscale structural fluctuations in materials."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#XEOL",
@@ -792,7 +792,7 @@
     "iri": "http://purl.org/pan-science/ESRFET#XLD",
     "names": [
       "XLD",
-      "X-Ray Linear Dichroism"
+      "X-ray Linear Dichroism"
     ],
     "description": "X-ray Linear Dichroism (XLD) measures the difference in X-ray absorption for linearly polarized light oriented along different crystallographic axes, providing information on electronic anisotropy and orbital ordering."
   },
@@ -850,9 +850,9 @@
     "iri": "http://purl.org/pan-science/ESRFET#XPCS",
     "names": [
       "XPCS",
-      "X-Ray Photon Correlation Spectroscopy"
+      "X-ray Photon Correlation Spectroscopy"
     ],
-    "description": "X-Ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes."
+    "description": "X-ray Photon Correlation Spectroscopy (XPCS) measures time fluctuations of coherent X-ray scattering intensity to probe nanoscale dynamics and temporal correlations in materials such as particle motion, phase transitions, or relaxation processes."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#XPCT",
@@ -882,9 +882,9 @@
     "iri": "http://purl.org/pan-science/ESRFET#XRCT",
     "names": [
       "XRCT",
-      "X-Ray Computed Tomography"
+      "X-ray Computed Tomography"
     ],
-    "description": "X-Ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample."
+    "description": "X-ray Computed Tomography (XRCT) measures X-ray absorption (transmission) of a sample from multiple angles and reconstructs a 3D volume, providing detailed internal structural information such as density variations, morphology, and defects without destroying the sample."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#XRD",
@@ -932,10 +932,10 @@
     "iri": "http://purl.org/pan-science/ESRFET#XRT",
     "names": [
       "XRT",
-      "X-Ray Topography",
-      "X-Ray Diffraction Topography",
+      "X-ray Topography",
+      "X-ray Diffraction Topography",
       "XDT"
     ],
-    "description": "X-Ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure."
+    "description": "X-ray Diffraction Topography (XRT) records spatial variations in the intensity of X-ray diffraction from a crystal to image defects, dislocations, and strain fields with high spatial resolution, revealing crystal quality and internal microstructure."
   }
 ]

--- a/src/esrf_ontologies/db/ESRFET.json
+++ b/src/esrf_ontologies/db/ESRFET.json
@@ -233,7 +233,15 @@
       "GISAXS",
       "Grazing Incidence Small Angle X-ray Scattering"
     ],
-    "description": "Grazing Incidence Small Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about surface and thin film morphology, including size, shape, and arrangement of nanostructures."
+    "description": "Grazing-Incidence Small-Angle X-ray Scattering (GISAXS) measures scattered X-rays at small angles from a sample surface under shallow incidence, providing nanoscale information about thin film and surface morphology, including size, shape, and arrangement of nanostructures."
+  },
+  {
+    "iri": "http://purl.org/pan-science/ESRFET#GIWAXS",
+    "names": [
+      "GIWAXS",
+      "Grazing Incidence Wide Angle X-ray Scattering"
+    ],
+    "description": "Grazing-Incidence Wide-Angle X-ray Scattering (GIWAXS) measures scattered X-rays at wide angles under shallow incidence, providing information on molecular packing, crystalline order, and orientation in thin films and surfaces."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#GIXRD",
@@ -241,7 +249,7 @@
       "GIXRD",
       "Grazing Incidence X-Ray Diffraction"
     ],
-    "description": "Grazing Incidence X-Ray Diffraction (GIXRD) measures diffraction from a sample surface using X-rays at very shallow incident angles, providing structural information about thin films, surfaces, and near-surface regions."
+    "description": "Grazing-Incidence X-ray Diffraction (GIXRD) measures diffraction patterns from a sample surface using X-rays at very shallow incident angles, providing structural information on thin films, surfaces, and near-surface regions, including phase composition and strain."
   },
   {
     "iri": "http://purl.org/pan-science/ESRFET#HAXPES",


### PR DESCRIPTION
See changelog for changes: added GIWAXS and harmonized existing GISAXS and GIXRD + semantic meaning for all three.

Note: replaced some "X-Ray" with "X-ray" in some "skos:prefLabel" and "rdfs:comment". This does not break the ontology: labels for humans, not part of the formal semantics.