### PR TITLE
Map to panet: CDI, EXAFS, ED-EXAFS, FTIR

### DIFF
--- a/ontologies/esrfet/ESRFET.owl
+++ b/ontologies/esrfet/ESRFET.owl
@@ -826,6 +826,10 @@
         </ObjectIntersectionOf>
     </EquivalentClasses>
     <EquivalentClasses>
+        <Class IRI="#CDI"/>
+        <Class IRI="http://purl.org/pan-science/PaNET/PaNET01174"/>
+    </EquivalentClasses>
+    <EquivalentClasses>
         <Class IRI="#CRYO-EM"/>
         <ObjectIntersectionOf>
             <Class IRI="#experimental_technique"/>
@@ -871,6 +875,10 @@
                 <Class IRI="#polycrystalline_sample"/>
             </ObjectSomeValuesFrom>
         </ObjectIntersectionOf>
+    </EquivalentClasses>
+    <EquivalentClasses>
+        <Class IRI="#ED-EXAFS"/>
+        <Class IRI="http://purl.org/pan-science/PaNET/PaNET01321"/>
     </EquivalentClasses>
     <EquivalentClasses>
         <Class IRI="#ED-EXAFS"/>
@@ -1062,6 +1070,10 @@
     </EquivalentClasses>
     <EquivalentClasses>
         <Class IRI="#EXAFS"/>
+        <Class IRI="http://purl.org/pan-science/PaNET/PaNET01198"/>
+    </EquivalentClasses>
+    <EquivalentClasses>
+        <Class IRI="#EXAFS"/>
         <ObjectIntersectionOf>
             <Class IRI="#experimental_technique"/>
             <ObjectSomeValuesFrom>
@@ -1241,6 +1253,10 @@
                 <Class IRI="#x-ray"/>
             </ObjectSomeValuesFrom>
         </ObjectIntersectionOf>
+    </EquivalentClasses>
+    <EquivalentClasses>
+        <Class IRI="#FTIR"/>
+        <Class IRI="http://purl.org/pan-science/PaNET/PaNET01320"/>
     </EquivalentClasses>
     <EquivalentClasses>
         <Class IRI="#FTIR"/>
@@ -5437,32 +5453,32 @@ Ultra Large structural features: large aggregates, clusters, and larger pores</L
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="foaf:name"/>
-        <AnonymousIndividual nodeID="_:genid2147484479"/>
+        <AnonymousIndividual nodeID="_:genid2147485310"/>
         <Literal>Giannis Koumoutsos</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="schema:affiliation"/>
-        <AnonymousIndividual nodeID="_:genid2147484480"/>
-        <AnonymousIndividual nodeID="_:genid2147484481"/>
+        <AnonymousIndividual nodeID="_:genid2147485311"/>
+        <AnonymousIndividual nodeID="_:genid2147485312"/>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="foaf:name"/>
-        <AnonymousIndividual nodeID="_:genid2147484480"/>
+        <AnonymousIndividual nodeID="_:genid2147485311"/>
         <Literal>Wout De Nolf</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:seeAlso"/>
-        <AnonymousIndividual nodeID="_:genid2147484481"/>
+        <AnonymousIndividual nodeID="_:genid2147485312"/>
         <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#anyURI">https://ror.org/02550n020</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="foaf:homepage"/>
-        <AnonymousIndividual nodeID="_:genid2147484481"/>
+        <AnonymousIndividual nodeID="_:genid2147485312"/>
         <Literal datatypeIRI="http://www.w3.org/2001/XMLSchema#anyURI">http://www.esrf.fr</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="foaf:name"/>
-        <AnonymousIndividual nodeID="_:genid2147484481"/>
+        <AnonymousIndividual nodeID="_:genid2147485312"/>
         <Literal>ESRF</Literal>
     </AnnotationAssertion>
 </Ontology>


### PR DESCRIPTION
We need to examine all the implications of the mappings and trace any semantic inconsistency introduced.

With the FTIR we need to check the following implications
<img width="420" height="527" alt="Screenshot 2025-12-03 at 09 13 56" src="https://github.com/user-attachments/assets/64c78c00-0852-4e8c-b199-ac3e2e7f6962" />

CDI:
<img width="334" height="587" alt="image" src="https://github.com/user-attachments/assets/b08f0bce-91cd-473d-8227-559de2e84ca5" />

EXAFS:
<img width="485" height="772" alt="image" src="https://github.com/user-attachments/assets/7cf57e9a-40c6-4759-a26e-2db1df9fe115" />


ED-EXAFS:
<img width="560" height="1035" alt="image" src="https://github.com/user-attachments/assets/9260e592-64e4-45b6-acfc-878a48df0add" />

