### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.2.0]
+
 ### Added
 
 - Semantic properties: temperature and pressure regimes.
@@ -68,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API for adding scan metadata to HDF5 and dataset metadata to the ESRF data portal.
 - OWL Ontology transpilation for runtime performance.
 
-[unreleased]: https://github.com/pan-ontologies/esrf-ontologies/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/pan-ontologies/esrf-ontologies/compare/v1.0.0...1.1.0
+[unreleased]: https://github.com/pan-ontologies/esrf-ontologies/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/pan-ontologies/esrf-ontologies/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/pan-ontologies/esrf-ontologies/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/pan-ontologies/esrf-ontologies/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "esrf-ontologies"
-version = "1.1.0"
+version = "1.2.0"
 authors = [{name = "ESRF", email = "dau-pydev@esrf.fr"}]
 description = "ESRF Ontologies"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
- I didn't upgrade the ontology version, as it's not clear to me what the versioning of the OWL file should be. moreover it is not yet completely public. But if you think we should, let me know and I'll do it.
- Fix comparison links in CHANGELOG.