### PR TITLE
docs: add versioned ESRFET URL

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,10 @@ import os
 import sys
 from importlib.metadata import version as get_version
 
+from esrf_ontologies.technique import get_ontology_version
+
 release = get_version("esrf-ontologies")
+esrfet_version = get_ontology_version()
 
 sys.path.append(os.path.abspath("_ext"))
 
@@ -40,6 +43,10 @@ autodoc_default_flags = [
     "undoc-members",
     "show-inheritance",
 ]
+
+rst_epilog = f"""
+.. _esrfet: https://w3id.org/PaN/ESRFET/{esrfet_version}
+"""
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@ The *ESRF Ontologies* project provides ontologies related to `ESRF <https://esrf
 
 Ontologies:
 
-* *ESRFET* is an ontology of experimental techniques used at the ESRF connected to
+* `ESRFET <esrfet_>`_ is an ontology of experimental techniques used at the ESRF connected to
   the `PaNET <https://doi.org/10.5281/zenodo.4806026>`_ ontology.
 
 Python API's:


### PR DESCRIPTION
I did not add it to the README (which is on PyPi for each version) because we will surely forget to update the link.