### PR TITLE
Migrate to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = E203,E501,E701
-max-line-length = 88
-exclude = [".eggs"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Run linting with Flake8
+      - name: Lint and format check with Ruff
         if: ${{ matrix.python-version == '3.12' }}
         run: |
-          pip install "flake8 >=4"
-          flake8 .
-
-      - name: Check code formatting with Black
-        if: ${{ matrix.python-version == '3.12' }}
-        run: |
-          pip install "black >=25"
-          black --check .
-
-      - name: Check import sorting with isort
-        if: ${{ matrix.python-version == '3.12' }}
-        run: |
-          pip install isort
-          isort --check-only .
+          pip install ruff
+          ruff --version
+          ruff check .
+          ruff format --check .
 
       - name: Build source distribution
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 !.gitignore
 !.github
 !.readthedocs.yaml
-!.flake8
 
 # Byte / compiled / optimized
 *.py[cod]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,20 +6,13 @@ Development requirements are listed in `pyproject.toml` and can be installed wit
 pip install [--user] [-e] .[dev]
 ```
 
-## Formatting
+## Formatting and linting
 
-[black](https://black.readthedocs.io/en/stable) is used to auto-format the code.
-
-```bash
-black .
-```
-
-## Linting
-
-[flake8](https://flake8.pycqa.org/en/latest/index.html) is used to lint the code.
+[ruff](https://docs.astral.sh/ruff/) is used to auto-format and lint the code.
 
 ```bash
-flake8
+ruff format .
+ruff check .
 ```
 
 ## Ontology transpilation

--- a/doc/_ext/technique_table.py
+++ b/doc/_ext/technique_table.py
@@ -11,7 +11,6 @@ VISIBLE_COLUMNS = ["Name", "Alternative names", "Description"]
 
 
 class InsertTechniqueTable(Directive):
-
     def run(self):
         rows = _generate_table_data()
         count_paragraph = self._create_technique_count(len(rows))

--- a/doc/_ext/technique_table.py
+++ b/doc/_ext/technique_table.py
@@ -127,8 +127,8 @@ class InsertTechniqueTable(Directive):
 
 def _generate_table_data() -> List[Dict[str, Any]]:
     filename = os.path.join(os.path.dirname(__file__), "techniques.json")
-    with open(filename, "r") as f:
-        return json.load(f, ensure_ascii=False)
+    with open(filename, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,8 @@ test = [
 ]
 dev = [
     "esrf-ontologies[test]",
-    "black >=22",
-    "flake8 >=4",
+    "ruff",
     "owlready2",
-    "isort",
 ]
 doc = [
     "esrf-ontologies[test]",
@@ -57,7 +55,18 @@ where = ["src"]
 [tool.coverage.run]
 omit = ['*/tests/*']
 
-[tool.isort]
-profile = "black"
-force_single_line = true
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "I", # isort
+]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+known-first-party = ["esrf_ontologies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,14 @@ select = [
     "E", # pycodestyle errors
     "F", # pyflakes
     "I", # isort
+    "S", # flake8-bandit
 ]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**" = [
+    "S101", # allow asserts
+]
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/src/esrf_ontologies/db/__init__.py
+++ b/src/esrf_ontologies/db/__init__.py
@@ -18,5 +18,5 @@ else:
 
 def load_techniques(name: str) -> List[Dict[str, Any]]:
     json_file = importlib_resources.files(__package__).joinpath(f"{name}.json")
-    with open(json_file, "r") as f:
+    with open(json_file, "r", encoding="utf-8") as f:
         return json.load(f)


### PR DESCRIPTION
Replace black+flake8+isort+bandit with ruff.

```bash
ruff check . --fix; ruff format
```

Also two UTF-8 fixes.